### PR TITLE
Add issue and PR template to spritz.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Issue
+_Briefly describe the issue you are experiencing / feature you would like to see added. Although the following sections are **Optional** the more information you provide, the faster this issue can be addressed._
+
+## Potential Solution [Optional]
+_Explain high level any potential solution to the issue as you see it_
+
+## Environment [Optional]
+* _Version of the project where the issue occurs_
+* _Real device or emulator_
+* _Mobile platform/Version_
+
+## Sample Code [Optional]
+_Sample code can be given to aid us understand all issues. In particular, sample code facilitates reproducing bugs, making it that much easier and faster for the issue to be addressed. Samples should be:_
+
+* _**Minimal** - Streamline your example. The more code there is to go through, the harder it is to find the problem._
+
+* _**Complete** - Make sure to include all information necessary to reproduce the problem._
+
+* _**Verifiable** - Ensure that the example actually reproduces the problem._
+
+See [here](https://stackoverflow.com/help/mcve) for more information.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Problem
+
+_Explain what is requested to do, or the problem you had to fix. Reference the Issue if one exists_
+
+## Solution
+
+_Explain high level how have you implemented the task, add any quirks or interesting information_
+
+### Test(s) added
+
+_Explain what you did test and what you didn't, and why_
+
+### Screenshots
+
+| Before | After |
+| ------ | ----- |
+| gif/png _before_ | gif/png _after_ |
+
+### Paired with
+
+_Specify @github-handle @or-handles, or write "Nobody" if you did not pair_


### PR DESCRIPTION
### Problem
As per the [novoda](https://github.com/novoda/novoda/wiki/Graduation-Process) base guidelines each open source repository should have a corresponding `issue` and `PR` template.

### Solution
This PR adds the aforementioned templates.

### Paired with
Nobody.